### PR TITLE
Add Sync-FilesFromSharePoint cmdlet

### DIFF
--- a/Private/Export-FilesFromSharePoint.ps1
+++ b/Private/Export-FilesFromSharePoint.ps1
@@ -1,0 +1,87 @@
+Function Export-FilesFromSharePoint {
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Parameter(Mandatory)][Array] $Source,
+        [Parameter(Mandatory)][Array] $Target,
+        [Parameter(Mandatory)][string] $TargetFolderPath
+    )
+
+    $CacheFilesTarget = [ordered] @{}
+    $ActionsToDo = [ordered] @{
+        "Add"     = [System.Collections.Generic.List[Object]]::new()
+        "Nothing" = [System.Collections.Generic.List[Object]]::new()
+        "Update"  = [System.Collections.Generic.List[Object]]::new()
+    }
+    foreach ($File in $Target) {
+        $CacheFilesTarget[$File.FullName] = $File
+    }
+
+    foreach ($File in $Source) {
+        if ($CacheFilesTarget[$File.FullName]) {
+            if (-not $File.PSIsContainer) {
+                $TargetFile = $CacheFilesTarget[$File.FullName]
+                if ($File.PSIsContainer -eq $TargetFile.PSiSContainer -and $File.TargetItemURL -eq $TargetFile.TargetItemURL -and $File.LastUpdated -eq $TargetFile.LastUpdated) {
+                    $ActionsToDo["Nothing"].Add($File)
+                } elseif ($File.PSIsContainer -eq $TargetFile.PSiSContainer -and $File.TargetItemURL -eq $TargetFile.TargetItemURL -and $File.LastUpdated -ne $TargetFile.LastUpdated) {
+                    $ActionsToDo["Update"].Add($File)
+                } elseif ($File.PSIsContainer -ne $TargetFile.PSiSContainer -or $File.TargetItemURL -ne $TargetFile.TargetItemURL) {
+                    Write-Color -Text "This should never happen 1" -Color Red
+                } else {
+                    Write-Color -Text "This should never happen 2" -Color Red
+                }
+            }
+        } else {
+            $ActionsToDo["Add"].Add($File)
+        }
+    }
+
+    Write-Color -Text "[i] ", "Total items to update: ", "$($ActionsToDo['Update'].Count)" -Color Yellow, White, Green
+    Write-Color -Text "[i] ", "Total items to add: ", "$($ActionsToDo['Add'].Count)" -Color Yellow, White, Green
+    Write-Color -Text "[i] ", "Total items matching: ", "$($ActionsToDo['Nothing'].Count)" -Color Yellow, White, Green
+
+    $Counter = 1
+    foreach ($SourceFile in $ActionsToDo["Add"] | Sort-Object TargetItemURL) {
+        $LocalDirectory = Split-Path $SourceFile.FullName -Parent
+        if ($SourceFile.PSIsContainer) {
+            if ($PSCmdlet.ShouldProcess($SourceFile.FullName, "Creating folder")) {
+                try {
+                    New-Item -ItemType Directory -Path $SourceFile.FullName -Force | Out-Null
+                } catch {
+                    Write-Color -Text "[!] ", "Error creating folder ", "'$($SourceFile.FullName)'", ". Error: ", $_.Exception.Message -Color Yellow, White, Yellow, Red
+                }
+            }
+        } else {
+            if ($PSCmdlet.ShouldProcess($SourceFile.FullName, "Downloading new file from SharePoint")) {
+                try {
+                    New-Item -ItemType Directory -Path $LocalDirectory -Force | Out-Null
+                    $null = Get-PnPFile -Url $SourceFile.TargetItemURL -Path $LocalDirectory -FileName (Split-Path $SourceFile.FullName -Leaf) -AsFile -Force -ErrorAction Stop
+                    (Get-Item -LiteralPath $SourceFile.FullName).LastWriteTime = $SourceFile.LastUpdated.ToLocalTime()
+                    Write-Color -Text "[+] ", "Downloading new file ", "($Counter of $($ActionsToDo['Add'].Count)) ", "'$($SourceFile.FullName)'" -Color Yellow, White, Yellow, White, Yellow, Cyan
+                } catch {
+                    Write-Color -Text "[!] ", "Error downloading file ", "'$($SourceFile.FullName)'", ". Error: ", $_.Exception.Message -Color Yellow, White, Yellow, Red
+                }
+            }
+        }
+        $Counter++
+    }
+
+    $Counter = 1
+    foreach ($SourceFile in $ActionsToDo["Update"] | Sort-Object TargetItemURL) {
+        $LocalDirectory = Split-Path $SourceFile.FullName -Parent
+        if ($SourceFile.PSIsContainer) {
+            # folders - nothing to update
+        } else {
+            if ($PSCmdlet.ShouldProcess($SourceFile.FullName, "Updating file from SharePoint")) {
+                try {
+                    $null = Get-PnPFile -Url $SourceFile.TargetItemURL -Path $LocalDirectory -FileName (Split-Path $SourceFile.FullName -Leaf) -AsFile -Force -ErrorAction Stop
+                    (Get-Item -LiteralPath $SourceFile.FullName).LastWriteTime = $SourceFile.LastUpdated.ToLocalTime()
+                    Write-Color -Text "[+] ", "Updating file ", "($Counter of $($ActionsToDo['Update'].Count)) ", "'$($SourceFile.FullName)'" -Color Yellow, White, Yellow, White, Yellow, Cyan
+                } catch {
+                    Write-Color -Text "[!] ", "Error updating file ", "'$($SourceFile.FullName)'", ". Error: ", $_.Exception.Message -Color Yellow, White, Yellow, Red
+                }
+            }
+        }
+        $Counter++
+    }
+}
+

--- a/Private/Remove-FilesFromLocal.ps1
+++ b/Private/Remove-FilesFromLocal.ps1
@@ -1,0 +1,75 @@
+Function Remove-FilesFromLocal {
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Array] $Source,
+        [Parameter(Mandatory)][Array] $Target,
+        [string[]] $ExcludeFromRemoval
+    )
+
+    if ($Target.Count -eq 0) {
+        Write-Color -Text "[i] ", "No items found in the Target. Skipping removal." -Color Yellow, White, Green
+        return
+    }
+
+    if ($Source.Count -gt 0) {
+        $FilesDiff = Compare-Object -ReferenceObject $Source -DifferenceObject $Target -Property FullName, PSIsContainer, TargetItemURL
+        [Array] $TargetDelta = foreach ($File in $FilesDiff) {
+            if ($File.SideIndicator -eq "=>") { $File }
+        }
+    } else {
+        $TargetDelta = $Target
+    }
+
+    if ($TargetDelta.Count -gt 0) {
+        Write-Color -Text "[information] ", "Found ", "$($TargetDelta.Count)", " differences in the Target. Removal is required." -Color Yellow, White, Yellow, White, Yellow, Red
+
+        $Counter = 1
+        :topLoop foreach ($TargetFile in $TargetDelta | Sort-Object TargetItemURL -Descending) {
+            if ($TargetFile.PSIsContainer) {
+                if (Test-Path -LiteralPath $TargetFile.FullName -PathType Container) {
+                    if ($ExcludeFromRemoval) {
+                        foreach ($Exclude in $ExcludeFromRemoval) {
+                            if ($TargetFile.TargetItemURL -like $Exclude) {
+                                Write-Color -Text "[!] ", "Folder ", "'$($TargetFile.TargetItemURL)'", " is excluded from removal." -Color Yellow, White, Yellow, Red
+                                continue topLoop
+                            }
+                        }
+                    }
+                    if ((Get-ChildItem -LiteralPath $TargetFile.FullName -Force | Measure-Object).Count -eq 0) {
+                        if ($PSCmdlet.ShouldProcess($TargetFile.FullName, "Removing folder from disk")) {
+                            Write-Color -Text "[-] ", "Removing Item ", "($Counter of $($TargetDelta.Count)) ", "'$($TargetFile.TargetItemURL)'" -Color Red, White, Yellow, Red
+                            try {
+                                Remove-Item -LiteralPath $TargetFile.FullName -Force -ErrorAction Stop
+                            } catch {
+                                Write-Color -Text "[!] ", "Failed to remove folder ", "'$($TargetFile.TargetItemURL)'", ". Error: ", $_.Exception.Message -Color Yellow, White, Yellow, Red
+                            }
+                        }
+                    } else {
+                        Write-Color -Text "[!] ", "Folder ", "'$($TargetFile.TargetItemURL)'", " is not empty. Skipping." -Color Yellow, White, Yellow, Red
+                    }
+                }
+            } else {
+                if (Test-Path -LiteralPath $TargetFile.FullName) {
+                    if ($ExcludeFromRemoval) {
+                        foreach ($Exclude in $ExcludeFromRemoval) {
+                            if ($TargetFile.TargetItemURL -like $Exclude) {
+                                Write-Color -Text "[!] ", "File ", "'$($TargetFile.TargetItemURL)'", " is excluded from removal." -Color Yellow, White, Yellow, Red
+                                continue topLoop
+                            }
+                        }
+                    }
+                    if ($PSCmdlet.ShouldProcess($TargetFile.FullName, "Removing file from disk")) {
+                        Write-Color -Text "[-] ", "Removing Item ", "($Counter of $($TargetDelta.Count)) ", "'$($TargetFile.TargetItemURL)'" -Color Red, White, Yellow, Red
+                        try {
+                            Remove-Item -LiteralPath $TargetFile.FullName -Force -ErrorAction Stop
+                        } catch {
+                            Write-Color -Text "[!] ", "Failed to remove file ", "'$($TargetFile.TargetItemURL)'", ". Error: ", $_.Exception.Message -Color Yellow, White, Yellow, Red
+                        }
+                    }
+                }
+            }
+            $Counter++
+        }
+    }
+}
+

--- a/Public/Sync-FilesFromSharePoint.ps1
+++ b/Public/Sync-FilesFromSharePoint.ps1
@@ -1,4 +1,45 @@
-﻿function Sync-FilesFromSharePoint {
+Function Sync-FilesFromSharePoint {
+    <#
+    .SYNOPSIS
+    Synchronizes files from SharePoint Online library to local folder
+
+    .DESCRIPTION
+    Synchronizes files from SharePoint Online library to local folder.
+    Provides an easy way to keep local folder in sync with SharePoint Online library
+    - Deleting content on SharePoint Online will delete it locally
+    - Adding content to SharePoint Online will add it locally
+    - Updating content on SharePoint Online will update it locally
+
+    .PARAMETER SiteURL
+    Site URL where the library is located
+
+    .PARAMETER TargetFolderPath
+    Local folder path to synchronize to
+
+    .PARAMETER SourceLibraryName
+    Name of the library on SharePoint Online to synchronize from
+
+    .PARAMETER LogPath
+    Path to log file where all actions will be logged
+
+    .PARAMETER LogMaximum
+    Maximum number of log files to keep
+
+    .PARAMETER LogShowTime
+    Show time in console output. Default $false. Logs will always have time
+
+    .PARAMETER LogTimeFormat
+    Time format to use in log file. Default "yyyy-MM-dd HH:mm:ss"
+
+    .PARAMETER Include
+    Include filter for files. Default "*.*"
+
+    .PARAMETER ExcludeFromRemoval
+    List of files/folders to exclude from removal. Default $null
+
+    .PARAMETER SkipRemoval
+    Skip removal of files/folders from local folder. Default $false
+    #>
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)][string] $SiteURL,
@@ -13,11 +54,14 @@
         [switch] $SkipRemoval
     )
 
-
     Set-LoggingCapabilities -LogPath $LogPath -LogMaximum $LogMaximum -ShowTime:$LogShowTime -TimeFormat $LogTimeFormat -ScriptPath $MyInvocation.ScriptName
 
     Write-Color -Text "[i] ", "Starting synchronization of files from ", $SiteURL, " to ", $TargetFolderPath -Color Yellow, White, Yellow, White, Green
     Write-Color -Text "[i] ", "Source library: ", $SourceLibraryName -Color Yellow, White, Green
+
+    if (-not (Test-Path -Path $TargetFolderPath)) {
+        New-Item -ItemType Directory -Path $TargetFolderPath -Force | Out-Null
+    }
 
     # Connect to SharePoint Online
     try {
@@ -34,4 +78,69 @@
         Write-Color -Text "[e] ", "Error: ", $_.Exception.Message -Color Yellow, Red
         return
     }
+
+    $TargetFolder = Find-TargetFolder -TargetLibraryName $SourceLibraryName -Library $Library -Web $Web
+    if (-not $TargetFolder) {
+        return
+    }
+
+    if ($web.ServerRelativeURL -eq "/") {
+        $TargetFolderSiteRelativeURL = $TargetFolder.ServerRelativeUrl
+    } else {
+        $TargetFolderSiteRelativeURL = $TargetFolder.ServerRelativeURL.Replace($Web.ServerRelativeUrl, [string]::Empty)
+    }
+
+    # Get files from SharePoint Online
+    $TargetFilesCount = 0
+    $TargetDirectoryCount = 0
+    $TargetFiles = Get-PnPListItem -List $SourceLibraryName -PageSize 2000
+    [Array] $Source = foreach ($File in $TargetFiles) {
+        $Date = $File.FieldValues.Modified.ToUniversalTime()
+        if ($File.FieldValues.FileRef -like "$($TargetFolder.ServerRelativeUrl)/*") {
+            [PSCustomObject]@{
+                FullName      = $File.FieldValues.FileRef.Replace($TargetFolder.ServerRelativeURL, $TargetFolderPath).Replace("/", "\\")
+                PSIsContainer = $File.FileSystemObjectType -eq "Folder"
+                TargetItemURL = $File.FieldValues.FileRef.Replace($Web.ServerRelativeUrl, [string]::Empty)
+                LastUpdated   = [datetime]::new($Date.Year, $Date.Month, $Date.Day, $Date.Hour, $Date.Minute, $Date.Second)
+            }
+            if (-not $File.FileSystemObjectType -eq "Folder") {
+                $TargetFilesCount++
+            } else {
+                $TargetDirectoryCount++
+            }
+        }
+    }
+    Write-Color -Text "[i] ", "Total items (files) in source: ", "$TargetFilesCount" -Color Yellow, White, Green
+    Write-Color -Text "[i] ", "Total items (folders) in source: ", "$TargetDirectoryCount" -Color Yellow, White, Green
+
+    $FilesLocalOutput = Get-FilesLocal -SourceFolderPath $TargetFolderPath -Include $Include -TargetFolderSiteRelativeURL $TargetFolderSiteRelativeURL
+    [Array] $Target = $FilesLocalOutput.Source
+
+    Write-Color -Text "[i] ", "Total items (files) in target: ", "$($FilesLocalOutput.SourceFilesCount)" -Color Yellow, White, Green
+    Write-Color -Text "[i] ", "Total items (folders) in target: ", "$($FilesLocalOutput.SourceDirectoryCount)" -Color Yellow, White, Green
+
+    Write-Color -Text "[i] ", "Starting processing files/folders from SharePoint ", $SiteUrl -Color Yellow, White, Green
+
+    $exportFilesFromSharePointSplat = @{
+        Source           = $Source
+        Target           = $Target
+        TargetFolderPath = $TargetFolderPath
+        WhatIf           = $WhatIfPreference
+    }
+    Export-FilesFromSharePoint @exportFilesFromSharePointSplat
+
+    if (-not $SkipRemoval) {
+        Write-Color -Text "[i] ", "Starting removal of files/folders from local path ", $TargetFolderPath -Color Yellow, White, Green
+        $removeFilesFromLocalSplat = @{
+            Source             = $Source
+            Target             = $Target
+            WhatIf             = $WhatIfPreference
+            ExcludeFromRemoval = $ExcludeFromRemoval
+        }
+        Remove-FilesFromLocal @removeFilesFromLocalSplat
+    } else {
+        Write-Color -Text "[i] ", "Skipping removal of files/folders from local path as requested", $TargetFolderPath -Color Yellow, White, Green
+    }
+    Write-Color -Text "[i] ", "Finished synchronization of files from ", $SiteURL, " to ", $TargetFolderPath -Color Yellow, White, Yellow, White, Green
 }
+

--- a/SharePointEssentials.psd1
+++ b/SharePointEssentials.psd1
@@ -6,7 +6,7 @@
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description          = 'Project to help with SharePoint synchronnization of files'
-    FunctionsToExport    = 'Sync-FilesToSharePoint'
+    FunctionsToExport    = 'Sync-FilesToSharePoint', 'Sync-FilesFromSharePoint'
     GUID                 = 'e9e31850-6388-4aa5-8e2b-897f6ac1866a'
     ModuleVersion        = '1.0.9'
     PowerShellVersion    = '5.1'

--- a/Tests/Sync-FilesFromSharePoint.Tests.ps1
+++ b/Tests/Sync-FilesFromSharePoint.Tests.ps1
@@ -1,0 +1,32 @@
+BeforeAll {
+    function Write-Color {}
+    function Set-LoggingCapabilities {}
+    function Get-PnPWeb {}
+    function Get-PnPList {}
+    function Get-PnPListItem {}
+    function Get-PnPFile {}
+    function Get-PnPFolderItem {}
+    function Export-FilesFromSharePoint {}
+    function Remove-FilesFromLocal {}
+    function Get-FilesLocal {}
+    function Find-TargetFolder {}
+    . "$PSScriptRoot/../Public/Sync-FilesFromSharePoint.ps1"
+}
+
+Describe 'Sync-FilesFromSharePoint' {
+    It 'calls private functions to process files' {
+        Mock Get-PnPWeb { @{ ServerRelativeUrl = '/' } }
+        Mock Get-PnPList { @{ RootFolder = @{ ServerRelativeUrl = '/Shared Documents' } } }
+        Mock Find-TargetFolder { @{ ServerRelativeUrl = '/Shared Documents' } }
+        Mock Get-PnPListItem { @() }
+        Mock Get-FilesLocal { @{ Source = @(); SourceDirectoryPath = '/tmp'; SourceFilesCount = 0; SourceDirectoryCount = 0 } }
+        Mock Export-FilesFromSharePoint { }
+        Mock Remove-FilesFromLocal { }
+
+        Sync-FilesFromSharePoint -SiteURL 'https://contoso.sharepoint.com/sites/test' -TargetFolderPath '/tmp' -SourceLibraryName 'Shared Documents' -WhatIf
+
+        Assert-MockCalled Export-FilesFromSharePoint -Times 1
+        Assert-MockCalled Remove-FilesFromLocal -Times 1
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Sync-FilesFromSharePoint cmdlet to mirror disk sync
- handle downloads and local cleanup with new private helpers
- cover sync behavior with Pester tests

## Testing
- `Invoke-Pester -Path Tests`

------
https://chatgpt.com/codex/tasks/task_e_688fd9b6fed8832e9daa483d81fbcfd3