### PR TITLE
Fix file comparison and add tests

### DIFF
--- a/Private/Export-FilesToSharepoint.ps1
+++ b/Private/Export-FilesToSharepoint.ps1
@@ -51,12 +51,12 @@
         if ($CacheFilesTarget[$File.FullName]) {
             if (-not $File.PSIsContainer) {
                 $TargetFile = $CacheFilesTarget[$File.FullName]
-                if ($Source.PSIsContainer -eq $TargetFile.PSiSContainer -and $Source.TargetItemURL -eq $TargetFile.TargetItemURL -and $Source.LastUpdated -eq $TargetFile.LastUpdated) {
+                if ($File.PSIsContainer -eq $TargetFile.PSiSContainer -and $File.TargetItemURL -eq $TargetFile.TargetItemURL -and $File.LastUpdated -eq $TargetFile.LastUpdated) {
                     $ActionsToDo["Nothing"].Add($File)
-                } elseif ($Source.PSIsContainer -eq $TargetFile.PSiSContainer -and $Source.TargetItemURL -eq $TargetFile.TargetItemURL -and $Source.LastUpdated -ne $TargetFile.LastUpdated) {
+                } elseif ($File.PSIsContainer -eq $TargetFile.PSiSContainer -and $File.TargetItemURL -eq $TargetFile.TargetItemURL -and $File.LastUpdated -ne $TargetFile.LastUpdated) {
                     #Write-Color -Text "[>] Update ", $($File.FullName), " is required. Dates are different: ", "$($File.LastUpdated)", " vs ", "$($TargetFile.LastUpdated)" -Color Yellow, White, Yellow, White, Yellow, Red
                     $ActionsToDo["Update"].Add($File)
-                } elseif ($Source.PSIsContainer -ne $TargetFile.PSiSContainer -or $Source.TargetItemURL -ne $TargetFile.TargetItemURL) {
+                } elseif ($File.PSIsContainer -ne $TargetFile.PSiSContainer -or $File.TargetItemURL -ne $TargetFile.TargetItemURL) {
                     # not really needed here
                     Write-Color -Text "This should never happen 1" -Color Red
                 } else {

--- a/Tests/Export-FilesToSharePoint.Tests.ps1
+++ b/Tests/Export-FilesToSharePoint.Tests.ps1
@@ -1,0 +1,46 @@
+BeforeAll {
+    function Write-Color {}
+    function Add-PnPFile {}
+    function Get-PnPListItem {}
+    Add-Type 'namespace Microsoft.SharePoint.Client { public class ClientObject { public string ServerRelativeUrl {get;set;} } }'
+    . "$PSScriptRoot/../Private/Export-FilesToSharepoint.ps1"
+}
+
+Describe 'Export-FilesToSharePoint' {
+    It 'uploads only when files differ from target' {
+        $Web = [pscustomobject]@{ ServerRelativeUrl = '/' }
+        $targetFolder = [Microsoft.SharePoint.Client.ClientObject]::new()
+        $targetFolder.ServerRelativeUrl = '/Shared Documents'
+        $source = @(
+            [pscustomobject]@{
+                FullName      = 'C:\\local\\match.txt'
+                PSIsContainer = $false
+                TargetItemURL = '/Shared Documents/match.txt'
+                LastUpdated   = [datetime]'2024-01-01'
+            },
+            [pscustomobject]@{
+                FullName      = 'C:\\local\\update.txt'
+                PSIsContainer = $false
+                TargetItemURL = '/Shared Documents/update.txt'
+                LastUpdated   = [datetime]'2024-01-01'
+            }
+        )
+        Mock Get-PnPListItem {
+            @(
+                [pscustomobject]@{
+                    FieldValues = @{ Modified = [datetime]'2024-01-01'; FileRef = '/Shared Documents/match.txt' }
+                    FileSystemObjectType = 'File'
+                },
+                [pscustomobject]@{
+                    FieldValues = @{ Modified = [datetime]'2023-01-01'; FileRef = '/Shared Documents/update.txt' }
+                    FileSystemObjectType = 'File'
+                }
+            )
+        }
+        Mock Add-PnPFile {}
+
+        Export-FilesToSharePoint -Source $source -SourceFolderPath 'C:\\local' -TargetLibraryName 'Shared Documents' -TargetFolder $targetFolder
+
+        Assert-MockCalled Add-PnPFile -Times 1
+    }
+}


### PR DESCRIPTION
## Summary
- correct file comparison by using the current item variable instead of the source array
- add Pester test for matching and differing files

## Testing
- `Invoke-Pester -Output Detailed`


------
https://chatgpt.com/codex/tasks/task_e_689050832bb0832e8aed3c3d8d3012f6