### PR TITLE
Add usage example for Sync-FilesFromSharePoint

### DIFF
--- a/Public/Sync-FilesFromSharePoint.ps1
+++ b/Public/Sync-FilesFromSharePoint.ps1
@@ -39,6 +39,27 @@ Function Sync-FilesFromSharePoint {
 
     .PARAMETER SkipRemoval
     Skip removal of files/folders from local folder. Default $false
+    
+    .EXAMPLE
+    $Url = 'https://yoursharepoint.sharepoint.com/sites/TheDashboard'
+    $ClientID = '438511c4' # Temp SharePoint App
+    $TenantID = 'ceb371f6'
+
+    Connect-PnPOnline -Url $Url -ClientId $ClientID -Thumbprint '2EC7C86E1AF0E434E93DE3EAC' -Tenant $TenantID
+
+    $syncFiles = @{
+        SiteURL          = 'https://yoursharepoint.sharepoint.com/sites/TheDashboard'
+        TargetFolderPath = "C:\\Support\\GitHub\\TheDashboard\\Examples\\Reports"
+        SourceLibraryName = "Shared Documents"
+        LogPath          = "$PSScriptRoot\\Logs\\Sync-FilesFromSharePoint-$($(Get-Date).ToString('yyyy-MM-dd_HH_mm_ss')).log"
+        LogMaximum       = 5
+        Include          = "*.aspx"
+    }
+
+    Sync-FilesFromSharePoint @syncFiles -WhatIf
+
+    .NOTES
+    General notes
     #>
     [CmdletBinding(SupportsShouldProcess)]
     param(


### PR DESCRIPTION
## Summary
- document how to connect and call Sync-FilesFromSharePoint with a practical example

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: The term 'Invoke-Pester' is not recognized)*
- `pwsh -NoLogo -NoProfile -Command "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force; Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-Module Pester -Scope CurrentUser -Force"` *(fails: No match was found for the provider 'NuGet')*


------
https://chatgpt.com/codex/tasks/task_e_68905ca66b90832eb2509598fd520e35