### PR TITLE
Pass SharePoint web object to file sync helpers

### DIFF
--- a/Private/Export-FilesToSharepoint.ps1
+++ b/Private/Export-FilesToSharepoint.ps1
@@ -4,7 +4,8 @@
         [Parameter(Mandatory)][Array] $Source,
         [Parameter(Mandatory)][string] $SourceFolderPath,
         [Parameter(Mandatory)][string] $TargetLibraryName,
-        [Parameter(Mandatory)][Microsoft.SharePoint.Client.ClientObject] $TargetFolder
+        [Parameter(Mandatory)][Microsoft.SharePoint.Client.ClientObject] $TargetFolder,
+        [Parameter(Mandatory)][Microsoft.SharePoint.Client.Web] $Web
     )
     # Get all files from SharePoint Online
     $TargetFilesCount = 0

--- a/Private/Remove-FilesFromSharePoint.ps1
+++ b/Private/Remove-FilesFromSharePoint.ps1
@@ -6,6 +6,7 @@
         [Parameter(Mandatory)] [string] $SourceFolderPath,
         [Parameter(Mandatory)] [string] $TargetLibraryName,
         $TargetFolder,
+        [Parameter(Mandatory)][Microsoft.SharePoint.Client.Web] $Web,
         [string[]] $ExcludeFromRemoval
     )
     # Get all files on SharePoint Online

--- a/Public/Sync-FilesToSharePoint.ps1
+++ b/Public/Sync-FilesToSharePoint.ps1
@@ -132,6 +132,7 @@
         SourceFolderPath  = $SourceDirectoryPath
         TargetLibraryName = $TargetLibraryName
         TargetFolder      = $TargetFolder
+        Web               = $Web
         WhatIf            = $WhatIfPreference
     }
     Export-FilesToSharePoint @exportFilesToSharePointSplat
@@ -146,6 +147,7 @@
             SourceFolderPath   = $SourceDirectoryPath
             TargetLibraryName  = $TargetLibraryName
             TargetFolder       = $TargetFolder
+            Web                = $Web
             WhatIf             = $WhatIfPreference
             ExcludeFromRemoval = $ExcludeFromRemoval
         }

--- a/Tests/Export-FilesToSharePoint.Tests.ps1
+++ b/Tests/Export-FilesToSharePoint.Tests.ps1
@@ -3,12 +3,14 @@ BeforeAll {
     function Add-PnPFile {}
     function Get-PnPListItem {}
     Add-Type 'namespace Microsoft.SharePoint.Client { public class ClientObject { public string ServerRelativeUrl {get;set;} } }'
+    Add-Type 'namespace Microsoft.SharePoint.Client { public class Web { public string ServerRelativeUrl {get;set;} } }'
     . "$PSScriptRoot/../Private/Export-FilesToSharepoint.ps1"
 }
 
 Describe 'Export-FilesToSharePoint' {
     It 'uploads only when files differ from target' {
-        $Web = [pscustomobject]@{ ServerRelativeUrl = '/' }
+        $Web = [Microsoft.SharePoint.Client.Web]::new()
+        $Web.ServerRelativeUrl = '/'
         $targetFolder = [Microsoft.SharePoint.Client.ClientObject]::new()
         $targetFolder.ServerRelativeUrl = '/Shared Documents'
         $source = @(
@@ -39,7 +41,7 @@ Describe 'Export-FilesToSharePoint' {
         }
         Mock Add-PnPFile {}
 
-        Export-FilesToSharePoint -Source $source -SourceFolderPath 'C:\\local' -TargetLibraryName 'Shared Documents' -TargetFolder $targetFolder
+        Export-FilesToSharePoint -Source $source -SourceFolderPath 'C:\\local' -TargetLibraryName 'Shared Documents' -TargetFolder $targetFolder -Web $Web
 
         Assert-MockCalled Add-PnPFile -Times 1
     }

--- a/Tests/Sync-FilesToSharePoint.Tests.ps1
+++ b/Tests/Sync-FilesToSharePoint.Tests.ps1
@@ -5,8 +5,8 @@ BeforeAll {
     function Get-PnPList {}
     function Get-FilesLocal {}
     function Find-TargetFolder {}
-    function Export-FilesToSharePoint { param($Source,$SourceFolderPath,$TargetLibraryName,$TargetFolder,[switch]$WhatIf) }
-    function Remove-FilesFromSharePoint { param($Source,$SiteURL,$SourceFolderPath,$TargetLibraryName,$TargetFolder,[switch]$WhatIf,$ExcludeFromRemoval) }
+    function Export-FilesToSharePoint { param($Source,$SourceFolderPath,$TargetLibraryName,$TargetFolder,$Web,[switch]$WhatIf) }
+    function Remove-FilesFromSharePoint { param($Source,$SiteURL,$SourceFolderPath,$TargetLibraryName,$TargetFolder,$Web,[switch]$WhatIf,$ExcludeFromRemoval) }
     Add-Type 'namespace Microsoft.SharePoint.Client { public class ClientObject { public string ServerRelativeUrl {get;set;} } }'
     . "$PSScriptRoot/../Public/Sync-FilesToSharePoint.ps1"
 }
@@ -30,6 +30,7 @@ Describe 'Sync-FilesToSharePoint' {
         Assert-MockCalled Export-FilesToSharePoint -Times 1 -ParameterFilter {
             $SourceFolderPath -eq '/tmp' -and
             $TargetLibraryName -eq 'Shared Documents' -and
+            $Web.ServerRelativeUrl -eq '/' -and
             $WhatIf
         }
 
@@ -37,6 +38,7 @@ Describe 'Sync-FilesToSharePoint' {
             $SiteURL -eq $siteUrl -and
             $SourceFolderPath -eq '/tmp' -and
             $TargetLibraryName -eq 'Shared Documents' -and
+            $Web.ServerRelativeUrl -eq '/' -and
             $WhatIf -and
             $null -eq $ExcludeFromRemoval
         }


### PR DESCRIPTION
## Summary
- accept explicit `Web` parameter in file sync helper functions
- forward `Web` object from `Sync-FilesToSharePoint`
- update tests to provide the web object

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"` *(failed: command not found)*
- `apt-get install -y powershell` *(failed: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_689068813990832eb2327db3e1c2f7df