### PR TITLE
Consolidate Get-ChildItem usage

### DIFF
--- a/Private/Get-FilesLocal.ps1
+++ b/Private/Get-FilesLocal.ps1
@@ -39,14 +39,11 @@
             Path    = $SourceFolderPath
             Recurse = $true
         }
-        if ($Include) {
-            $getChildItemSplat["Include"] = $Include
-        }
         try {
-            $SourceItems = @(
-                Get-ChildItem -Directory -Path $SourceFolderPath -Recurse -ErrorAction Stop
-                Get-ChildItem @getChildItemSplat -ErrorAction Stop
-            )
+            $SourceItems = Get-ChildItem @getChildItemSplat -ErrorAction Stop
+            if ($Include) {
+                $SourceItems = $SourceItems.Where({ $_.PSIsContainer -or $_.Name -like $Include })
+            }
         } catch {
             Write-Color -Text "[e] ", "Unable to get files from the source folder. Make sure the path is correct and you have permissions to access it." -Color Yellow, Red
             Write-Color -Text "[e] ", "Error: ", $_.Exception.Message -Color Yellow, Red

--- a/Tests/Get-FilesLocal.Tests.ps1
+++ b/Tests/Get-FilesLocal.Tests.ps1
@@ -1,0 +1,24 @@
+BeforeAll {
+    function Write-Color {}
+    . "$PSScriptRoot/../Private/Get-FilesLocal.ps1"
+}
+
+Describe 'Get-FilesLocal' {
+    It 'includes directories when filtering by Include' {
+        $root = Join-Path $TestDrive 'local'
+        New-Item -ItemType Directory -Path $root | Out-Null
+        $dir1 = Join-Path $root 'dir1'
+        $dir2 = Join-Path $root 'dir2'
+        $subdir = Join-Path $dir1 'subdir'
+        foreach ($d in @($dir1, $dir2, $subdir)) { New-Item -ItemType Directory -Path $d | Out-Null }
+        New-Item -ItemType File -Path (Join-Path $dir1 'a.txt') | Out-Null
+        New-Item -ItemType File -Path (Join-Path $dir2 'b.txt') | Out-Null
+        New-Item -ItemType File -Path (Join-Path $dir1 'c.log') | Out-Null
+
+        $result = Get-FilesLocal -SourceFolderPath $root -Include '*.txt' -TargetFolderSiteRelativeURL '/target'
+
+        $result.SourceFilesCount | Should -Be 2
+        $result.SourceDirectoryCount | Should -Be 3
+        ($result.Source.Where({ $_.PSIsContainer })).Count | Should -Be 3
+    }
+}


### PR DESCRIPTION
## Summary
- consolidate `Get-ChildItem` calls in `Get-FilesLocal` so a single invocation handles both files and directories
- use the array `.Where()` method instead of `Where-Object` to include directories when `-Include` filtering is applied
- add a Pester test ensuring directories are still returned when using an `Include` filter

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`
- `pwsh -NoLogo -NoProfile -Command "./Build/Build-Module.ps1"` *(fails: A parameter cannot be found that matches parameter name 'ModuleName')*

------
https://chatgpt.com/codex/tasks/task_e_689068b6d090832eb00bf19b8cfc628f