### PR TITLE
Handle Get-PnPListItem failures in file sync operations

### DIFF
--- a/Private/Export-FilesToSharepoint.ps1
+++ b/Private/Export-FilesToSharepoint.ps1
@@ -10,7 +10,12 @@
     # Get all files from SharePoint Online
     $TargetFilesCount = 0
     $TargetDirectoryCount = 0
-    $TargetFiles = Get-PnPListItem -List $TargetLibraryName -PageSize 2000
+    try {
+        $TargetFiles = Get-PnPListItem -List $TargetLibraryName -PageSize 2000 -ErrorAction Stop
+    } catch {
+        Write-Color -Text "[!] ", "Failed to retrieve list items for ", "'$TargetLibraryName'", ". Error: ", $_.Exception.Message -Color Yellow, White, Yellow, White, Red
+        return
+    }
     $Target = foreach ($File in $TargetFiles) {
         # Dates are not the same as in SharePoint, so we need to convert them to UTC
         # And make sure we don't add miliseconds

--- a/Private/Remove-FilesFromSharePoint.ps1
+++ b/Private/Remove-FilesFromSharePoint.ps1
@@ -10,7 +10,12 @@
         [string[]] $ExcludeFromRemoval
     )
     # Get all files on SharePoint Online
-    $TargetFiles = Get-PnPListItem -List $TargetLibraryName -PageSize 2000
+    try {
+        $TargetFiles = Get-PnPListItem -List $TargetLibraryName -PageSize 2000 -ErrorAction Stop
+    } catch {
+        Write-Color -Text "[!] ", "Failed to retrieve list items for ", "'$TargetLibraryName'", ". Error: ", $_.Exception.Message -Color Yellow, White, Yellow, White, Red
+        return
+    }
 
     [Array] $Target = foreach ($File in $TargetFiles) {
         $Date = $File.FieldValues.Modified.ToUniversalTime()

--- a/Tests/Export-FilesToSharePoint.Tests.ps1
+++ b/Tests/Export-FilesToSharePoint.Tests.ps1
@@ -45,4 +45,18 @@ Describe 'Export-FilesToSharePoint' {
 
         Assert-MockCalled Add-PnPFile -Times 1
     }
+
+    It 'aborts when Get-PnPListItem fails' {
+        $Web = [Microsoft.SharePoint.Client.Web]::new()
+        $targetFolder = [Microsoft.SharePoint.Client.ClientObject]::new()
+        Mock Get-PnPListItem { throw 'fail' }
+        Mock Add-PnPFile {}
+        Mock Write-Color {}
+
+        $source = @([pscustomobject]@{})
+        Export-FilesToSharePoint -Source $source -SourceFolderPath 'C:\local' -TargetLibraryName 'Shared Documents' -TargetFolder $targetFolder -Web $Web
+
+        Assert-MockCalled Write-Color -Times 1
+        Assert-MockCalled Add-PnPFile -Times 0
+    }
 }

--- a/Tests/Remove-FilesFromSharePoint.Tests.ps1
+++ b/Tests/Remove-FilesFromSharePoint.Tests.ps1
@@ -1,0 +1,26 @@
+BeforeAll {
+    function Write-Color {}
+    function Get-PnPListItem {}
+    function Get-PnPFolder {}
+    function Remove-PnPFile {}
+    function Get-PnPFile {}
+    Add-Type 'namespace Microsoft.SharePoint.Client { public class ClientObject { public string ServerRelativeUrl {get;set;} } }'
+    Add-Type 'namespace Microsoft.SharePoint.Client { public class Web { public string ServerRelativeUrl {get;set;} } }'
+    . "$PSScriptRoot/../Private/Remove-FilesFromSharePoint.ps1"
+}
+
+Describe 'Remove-FilesFromSharePoint' {
+    It 'aborts when Get-PnPListItem fails' {
+        $Web = [Microsoft.SharePoint.Client.Web]::new()
+        $targetFolder = [Microsoft.SharePoint.Client.ClientObject]::new()
+        $targetFolder.ServerRelativeUrl = '/Shared Documents'
+        Mock Get-PnPListItem { throw 'fail' }
+        Mock Remove-PnPFile {}
+        Mock Write-Color {}
+
+        Remove-FilesFromSharePoint -Source @() -SiteURL 'https://contoso.sharepoint.com/sites/test' -SourceFolderPath 'C:\local' -TargetLibraryName 'Shared Documents' -TargetFolder $targetFolder -Web $Web
+
+        Assert-MockCalled Write-Color -Times 1
+        Assert-MockCalled Remove-PnPFile -Times 0
+    }
+}


### PR DESCRIPTION
## Summary
- stop export/remove when `Get-PnPListItem` fails by wrapping in try/catch and using `-ErrorAction Stop`
- add Pester coverage for both export and remove failure paths

## Testing
- `Invoke-Pester -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_e_68909b2cd9bc832e9a3c1307c205cfe4