### PR TITLE
Add removal parameter tests for sync functions

### DIFF
--- a/Tests/Sync-FilesFromSharePoint.Tests.ps1
+++ b/Tests/Sync-FilesFromSharePoint.Tests.ps1
@@ -6,8 +6,8 @@ BeforeAll {
     function Get-PnPListItem {}
     function Get-PnPFile {}
     function Get-PnPFolderItem {}
-    function Export-FilesFromSharePoint {}
-    function Remove-FilesFromLocal {}
+    function Export-FilesFromSharePoint { param($Source,$Target,$TargetFolderPath,[switch]$WhatIf) }
+    function Remove-FilesFromLocal { param($Source,$Target,$WhatIf,$ExcludeFromRemoval) }
     function Get-FilesLocal {}
     function Find-TargetFolder {}
     . "$PSScriptRoot/../Public/Sync-FilesFromSharePoint.ps1"
@@ -27,6 +27,37 @@ Describe 'Sync-FilesFromSharePoint' {
 
         Assert-MockCalled Export-FilesFromSharePoint -Times 1
         Assert-MockCalled Remove-FilesFromLocal -Times 1
+    }
+
+    It 'skips removal when SkipRemoval is specified' {
+        Mock Get-PnPWeb { @{ ServerRelativeUrl = '/' } }
+        Mock Get-PnPList { @{ RootFolder = @{ ServerRelativeUrl = '/Shared Documents' } } }
+        Mock Find-TargetFolder { @{ ServerRelativeUrl = '/Shared Documents' } }
+        Mock Get-PnPListItem { @() }
+        Mock Get-FilesLocal { @{ Source = @(); SourceDirectoryPath = '/tmp'; SourceFilesCount = 0; SourceDirectoryCount = 0 } }
+        Mock Export-FilesFromSharePoint { }
+        Mock Remove-FilesFromLocal { }
+
+        Sync-FilesFromSharePoint -SiteURL 'https://contoso.sharepoint.com/sites/test' -TargetFolderPath '/tmp' -SourceLibraryName 'Shared Documents' -SkipRemoval -WhatIf
+
+        Assert-MockCalled Remove-FilesFromLocal -Times 0
+    }
+
+    It 'passes ExcludeFromRemoval to Remove-FilesFromLocal' {
+        $exclude = @('keep.txt','stay/dir')
+        Mock Get-PnPWeb { @{ ServerRelativeUrl = '/' } }
+        Mock Get-PnPList { @{ RootFolder = @{ ServerRelativeUrl = '/Shared Documents' } } }
+        Mock Find-TargetFolder { @{ ServerRelativeUrl = '/Shared Documents' } }
+        Mock Get-PnPListItem { @() }
+        Mock Get-FilesLocal { @{ Source = @(); SourceDirectoryPath = '/tmp'; SourceFilesCount = 0; SourceDirectoryCount = 0 } }
+        Mock Export-FilesFromSharePoint { }
+        $Global:received = $null
+        Mock Remove-FilesFromLocal { param($Source,$Target,$WhatIf,$ExcludeFromRemoval); $Global:received = $ExcludeFromRemoval }
+
+        Sync-FilesFromSharePoint -SiteURL 'https://contoso.sharepoint.com/sites/test' -TargetFolderPath '/tmp' -SourceLibraryName 'Shared Documents' -ExcludeFromRemoval $exclude -WhatIf
+
+        Assert-MockCalled Remove-FilesFromLocal -Times 1
+        $Global:received | Should -Be $exclude
     }
 }
 


### PR DESCRIPTION
## Summary
- cover SkipRemoval behaviour in Sync-FilesToSharePoint and Sync-FilesFromSharePoint
- ensure ExcludeFromRemoval is passed to removal routines

## Testing
- `Invoke-Pester`


------
https://chatgpt.com/codex/tasks/task_e_68909b3ce424832e8ad5b671cc95c7bc